### PR TITLE
feat: support UI config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This HA integration allows to import long term statistics from a file like csv o
 
 [![Community Forum][forum-shield]][forum]
 
-**This integration just offers a service**
+**This integration just offers an action (previously known as service)**
 
 ## Installation
 
@@ -18,9 +18,15 @@ This HA integration allows to import long term statistics from a file like csv o
 
 The preferred way is to use HACS:
 
-1. Add this integration to your HA installation via HACS (it is part of HACS, so no custom repository should be needed anymore)
-1. Add `import_statistics:` to your configuration .yaml (if it is possible to do this in the UI in some way without directly editing the yaml file, please let me know)
+1. Search and download this integration to your HA installation via HACS, or click:
+
+   [![Open HACS Repository][hacs-repo-badge]][hacs-repo]
+
 1. Restart home assistant
+
+1. Add this integration to Home Assistant, or click:
+
+   [![Add Integration][config-flow-badge]][config-flow]
 
 ### Manual installation
 
@@ -105,4 +111,7 @@ If you want to contribute to this please read the [Contribution guidelines](CONT
 [license-shield]: https://img.shields.io/github/license/klausj1/homeassistant-statistics.svg
 [releases-shield]: https://img.shields.io/github/v/release/klausj1/homeassistant-statistics?include_prereleases
 [releases]: https://github.com/klausj1/homeassistant-statistics/releases
-
+[hacs-repo-badge]: https://my.home-assistant.io/badges/hacs_repository.svg
+[hacs-repo]: https://my.home-assistant.io/redirect/hacs_repository/?owner=klausj1&repository=homeassistant-statistics&category=integration
+[config-flow-badge]: https://my.home-assistant.io/badges/config_flow_start.svg
+[config-flow]: https://my.home-assistant.io/redirect/config_flow_start?domain=import_statistics

--- a/custom_components/import_statistics/__init__.py
+++ b/custom_components/import_statistics/__init__.py
@@ -6,10 +6,10 @@ from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
     async_import_statistics,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.config_entries import ConfigEntry
 
 from custom_components.import_statistics import helpers, prepare_data
 from custom_components.import_statistics.const import ATTR_FILENAME, DOMAIN
@@ -69,6 +69,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:  # pylint: disable=u
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # pylint: disable=unused-argument  # noqa: ARG001
+    """Set up the device based on a config entry."""
     return True
 
 

--- a/custom_components/import_statistics/__init__.py
+++ b/custom_components/import_statistics/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.components.recorder.statistics import (
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.config_entries import ConfigEntry
 
 from custom_components.import_statistics import helpers, prepare_data
 from custom_components.import_statistics.const import ATTR_FILENAME, DOMAIN
@@ -64,6 +65,10 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:  # pylint: disable=u
     hass.services.register(DOMAIN, "import_from_file", handle_import_from_file)
 
     # Return boolean to indicate that initialization was successful.
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  # pylint: disable=unused-argument  # noqa: ARG001
     return True
 
 

--- a/custom_components/import_statistics/config_flow.py
+++ b/custom_components/import_statistics/config_flow.py
@@ -1,6 +1,9 @@
-from __future__ import annotations
+"""Handle a config flow initialized from UI."""
+
 from typing import Any
+
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+
 from .const import DOMAIN
 
 
@@ -9,9 +12,7 @@ class ImportStatisticsConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle a config flow initialized from UI."""
         if user_input is not None:
             return self.async_create_entry(title="Import Statistics", data={})

--- a/custom_components/import_statistics/config_flow.py
+++ b/custom_components/import_statistics/config_flow.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from typing import Any
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from .const import DOMAIN
+
+
+class ImportStatisticsConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Config flow for the Import Statistics integration."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a config flow initialized from UI."""
+        if user_input is not None:
+            return self.async_create_entry(title="Import Statistics", data={})
+
+        return self.async_show_form(step_id="user")
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Handle a config flow from configuration.yaml."""
+        return await self.async_step_user(import_data)

--- a/custom_components/import_statistics/manifest.json
+++ b/custom_components/import_statistics/manifest.json
@@ -9,14 +9,12 @@
         "recorder"
     ],
     "documentation": "https://github.com/klausj1/homeassistant-statistics",
-    "homekit": {},
     "integration_type": "service",
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/klausj1/homeassistant-statistics/issues",
     "requirements": [
         "pandas>=2.0.0"
     ],
-    "ssdp": [],
-    "version": "1.0.2",
-    "zeroconf": []
+    "single_config_entry": true,
+    "version": "1.0.2"
 }

--- a/custom_components/import_statistics/manifest.json
+++ b/custom_components/import_statistics/manifest.json
@@ -1,10 +1,10 @@
 {
     "domain": "import_statistics",
-    "name": "import_statistics",
+    "name": "Import Statistics",
     "codeowners": [
         "@klausj1"
     ],
-    "config_flow": false,
+    "config_flow": true,
     "dependencies": [
         "recorder"
     ],
@@ -17,6 +17,6 @@
         "pandas>=2.0.0"
     ],
     "ssdp": [],
-    "version": "1.0.1",
+    "version": "1.0.2",
     "zeroconf": []
 }

--- a/custom_components/import_statistics/strings.json
+++ b/custom_components/import_statistics/strings.json
@@ -30,5 +30,12 @@
                 }
             }
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "description": "[%key:common::config_flow::description::confirm_setup%]"
+            }
+        }
     }
 }

--- a/custom_components/import_statistics/translations/en.json
+++ b/custom_components/import_statistics/translations/en.json
@@ -28,7 +28,14 @@
                     "description": "True: Take unit from existing entity (only valid for internal statistics, e.g. sensor.sun_solar_azimuth); False: Take unit from own column in imported data"
                 }
             },
-            "name": "import_from_file"
+            "name": "Import statistics from file"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "description": "Do you want to add the Import Statistics integration to Home Assistant?"
+            }
         }
     }
 }


### PR DESCRIPTION
This patch adds support for the UI config flow, while retaining compatibility with legacy YAML config method. The code was tested against HA `2025.7.1` and `2025.3.0`.

<img width="1200" height="641" alt="image" src="https://github.com/user-attachments/assets/d30adcb4-31d1-4e1e-a6e4-883530d54a7b" />

<img width="1200" height="641" alt="image" src="https://github.com/user-attachments/assets/e451ae6d-df2b-4d08-9d6d-96834d689e7b" />

<img width="1200" height="641" alt="image" src="https://github.com/user-attachments/assets/30b27d10-b90e-4dfa-a1e6-65f38622f47d" />
