### PR TITLE
add support for delta import from JSON

### DIFF
--- a/custom_components/import_statistics/import_service_helper.py
+++ b/custom_components/import_statistics/import_service_helper.py
@@ -190,7 +190,7 @@ def prepare_json_data_to_import(call: ServiceCall, ha_timezone: str) -> tuple:
     """
     _, timezone_identifier, _, datetime_format = handle_arguments(call, ha_timezone, filename=None)
 
-    valid_columns = ["state", "sum", "min", "max", "mean"]
+    valid_columns = ["state", "sum", "min", "max", "mean", "delta"]
     columns = ["statistic_id", "unit", "start"]
     data = []
 


### PR DESCRIPTION
The delta field has not been added to the valid JSON fields to be processed, thus importing counter data from delta values via JSON import was not possible.
Works for me now.