### PR TITLE
Support name

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Import your statistics from CSV, TSV, or JSON files to populate or update Home A
 - **`timezone_identifier` (optional)**
   - Defaults to Home Assistant's configured timezone if omitted. Typically can be left empty.
   - Timezone identifier (check pytz timezones or <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>).
+- **`unit_class` (optional)**
+  - Sets the unit class for Energy Dashboard compatibility.
+  - Required for external statistics (with `:` in the ID) to appear in the Energy Dashboard.
+  - Common values: `energy` (for kWh, electricity/gas), `volume` (for water/m³), `power`, `temperature`.
+  - See [Home Assistant documentation](https://developers.home-assistant.io/blog/2025/10/16/recorder-statistics-api-changes/) for more details.
 
 > **Important:** Input files **must** contain a `unit` column with the unit of measurement for each statistic. For existing statistics, the unit in the input file must match the unit already stored in Home Assistant's database, otherwise the import will fail with an error.
 >
@@ -125,6 +130,34 @@ action: import_statistics.import_from_json
 data:
   statistics: <JSON content>
 ```
+
+##### Import for Energy Dashboard (external statistics)
+
+Use `unit_class` to enable external statistics in the Energy Dashboard:
+
+```yaml
+# Electricity import (external statistic with : in ID)
+action: import_statistics.import_from_file
+data:
+  filename: electricity_data.csv
+  delimiter: ","
+  decimal: "."
+  datetime_format: "%Y-%m-%d %H:%M"
+  unit_class: energy  # Required for Energy Dashboard
+```
+
+```yaml
+# Water import (external statistic with : in ID)
+action: import_statistics.import_from_file
+data:
+  filename: water_data.csv
+  delimiter: ","
+  decimal: "."
+  datetime_format: "%Y-%m-%d %H:%M"
+  unit_class: volume  # Required for Energy Dashboard
+```
+
+> **Note:** The `statistic_id` in your CSV file must use the external format (`domain:name` with `:`) for `unit_class` to work properly. Example: `sensor:imported_electricity`.
 
 ### File Format Requirements
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Import your statistics from CSV, TSV, or JSON files to populate or update Home A
   - Required for external statistics (with `:` in the ID) to appear in the Energy Dashboard.
   - Common values: `energy` (for kWh, electricity/gas), `volume` (for water/m³), `power`, `temperature`.
   - See [Home Assistant documentation](https://developers.home-assistant.io/blog/2025/10/16/recorder-statistics-api-changes/) for more details.
+- **`name` (optional)**
+  - Friendly display name for the statistic, stored in the database and shown by the Home Assistant frontend (Energy Dashboard, Statistics Graph card) for external statistics.
+  - Applies to all `statistic_id`s in the imported file.
+  - Re-importing with a `name` updates the stored name immediately (no deletion required).
 
 > **Important:** Input files **must** contain a `unit` column with the unit of measurement for each statistic. For existing statistics, the unit in the input file must match the unit already stored in Home Assistant's database, otherwise the import will fail with an error.
 >
@@ -133,7 +137,7 @@ data:
 
 ##### Import for Energy Dashboard (external statistics)
 
-Use `unit_class` to enable external statistics in the Energy Dashboard:
+Use `unit_class` to enable external statistics in the Energy Dashboard, and `name` to set the display label:
 
 ```yaml
 # Electricity import (external statistic with : in ID)
@@ -144,6 +148,7 @@ data:
   decimal: "."
   datetime_format: "%Y-%m-%d %H:%M"
   unit_class: energy  # Required for Energy Dashboard
+  name: Energy Provider (Electricity)  # Optional: friendly name shown in the frontend
 ```
 
 ```yaml
@@ -155,6 +160,7 @@ data:
   decimal: "."
   datetime_format: "%Y-%m-%d %H:%M"
   unit_class: volume  # Required for Energy Dashboard
+  name: Energy Provider (Water)  # Optional: friendly name shown in the frontend
 ```
 
 > **Note:** The `statistic_id` in your CSV file must use the external format (`domain:name` with `:`) for `unit_class` to work properly. Example: `sensor:imported_electricity`.

--- a/custom_components/import_statistics/const.py
+++ b/custom_components/import_statistics/const.py
@@ -13,6 +13,7 @@ ATTR_ENTITIES = "entities"
 ATTR_DELTA = "delta"
 ATTR_SPLIT_BY = "split_by"
 ATTR_COUNTER_FIELDS = "counter_fields"
+ATTR_UNIT_CLASS = "unit_class"
 
 TESTFILEPATHS = "tests/testfiles/"
 

--- a/custom_components/import_statistics/import_service.py
+++ b/custom_components/import_statistics/import_service.py
@@ -204,6 +204,7 @@ class PreparedImportData:
     datetime_format: str
     is_delta: bool
     unit_class: str | None
+    name: str | None = None
 
 
 async def _process_import(hass: HomeAssistant, data: PreparedImportData) -> None:
@@ -221,10 +222,10 @@ async def _process_import(hass: HomeAssistant, data: PreparedImportData) -> None
     if data.is_delta:
         _LOGGER.info("Delta mode detected, fetching references from database")
         references = await prepare_delta_handling(hass, data.df)
-        stats = await hass.async_add_executor_job(lambda: handle_dataframe_delta(data.df, references, data.unit_class))
+        stats = await hass.async_add_executor_job(lambda: handle_dataframe_delta(data.df, references, data.unit_class, data.name))
     else:
         _LOGGER.info("Non-delta mode, processing directly")
-        stats = await hass.async_add_executor_job(lambda: handle_dataframe_no_delta(data.df, data.unit_class))
+        stats = await hass.async_add_executor_job(lambda: handle_dataframe_no_delta(data.df, data.unit_class, data.name))
 
     await import_stats(hass, stats)
 
@@ -241,8 +242,9 @@ async def handle_import_from_file_impl(hass: HomeAssistant, call: ServiceCall) -
 
     _LOGGER.info("Preparing data for import ...")
     df, timezone_id, datetime_format, is_delta, unit_class = await hass.async_add_executor_job(lambda: prepare_data_to_import(file_path, call, ha_timezone))
+    name: str | None = call.data.get("name") or None
 
-    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, is_delta, unit_class))
+    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, is_delta, unit_class, name))
 
 
 async def handle_import_from_json_impl(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -254,8 +256,9 @@ async def handle_import_from_json_impl(hass: HomeAssistant, call: ServiceCall) -
 
     _LOGGER.info("Preparing data for import")
     df, timezone_id, datetime_format, is_delta, unit_class = await hass.async_add_executor_job(lambda: prepare_json_data_to_import(call, ha_timezone))
+    name: str | None = call.data.get("name") or None
 
-    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, is_delta, unit_class))
+    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, is_delta, unit_class, name))
 
 
 async def import_stats(hass: HomeAssistant, stats: dict) -> None:

--- a/custom_components/import_statistics/import_service.py
+++ b/custom_components/import_statistics/import_service.py
@@ -203,6 +203,7 @@ class PreparedImportData:
     timezone_id: str
     datetime_format: str
     is_delta: bool
+    unit_class: str | None
 
 
 async def _process_import(hass: HomeAssistant, data: PreparedImportData) -> None:
@@ -220,10 +221,10 @@ async def _process_import(hass: HomeAssistant, data: PreparedImportData) -> None
     if data.is_delta:
         _LOGGER.info("Delta mode detected, fetching references from database")
         references = await prepare_delta_handling(hass, data.df)
-        stats = await hass.async_add_executor_job(lambda: handle_dataframe_delta(data.df, references))
+        stats = await hass.async_add_executor_job(lambda: handle_dataframe_delta(data.df, references, data.unit_class))
     else:
         _LOGGER.info("Non-delta mode, processing directly")
-        stats = await hass.async_add_executor_job(lambda: handle_dataframe_no_delta(data.df))
+        stats = await hass.async_add_executor_job(lambda: handle_dataframe_no_delta(data.df, data.unit_class))
 
     await import_stats(hass, stats)
 
@@ -239,9 +240,9 @@ async def handle_import_from_file_impl(hass: HomeAssistant, call: ServiceCall) -
     ha_timezone = hass.config.time_zone
 
     _LOGGER.info("Preparing data for import ...")
-    df, timezone_id, datetime_format, is_delta = await hass.async_add_executor_job(lambda: prepare_data_to_import(file_path, call, ha_timezone))
+    df, timezone_id, datetime_format, is_delta, unit_class = await hass.async_add_executor_job(lambda: prepare_data_to_import(file_path, call, ha_timezone))
 
-    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, is_delta))
+    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, is_delta, unit_class))
 
 
 async def handle_import_from_json_impl(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -252,9 +253,9 @@ async def handle_import_from_json_impl(hass: HomeAssistant, call: ServiceCall) -
     ha_timezone = hass.config.time_zone
 
     _LOGGER.info("Preparing data for import")
-    df, timezone_id, datetime_format, is_delta = await hass.async_add_executor_job(lambda: prepare_json_data_to_import(call, ha_timezone))
+    df, timezone_id, datetime_format, is_delta, unit_class = await hass.async_add_executor_job(lambda: prepare_json_data_to_import(call, ha_timezone))
 
-    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, is_delta))
+    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, is_delta, unit_class))
 
 
 async def import_stats(hass: HomeAssistant, stats: dict) -> None:

--- a/custom_components/import_statistics/import_service_delta_helper.py
+++ b/custom_components/import_statistics/import_service_delta_helper.py
@@ -178,7 +178,7 @@ def convert_deltas_with_newer_reference(
     return converted_rows
 
 
-def handle_dataframe_delta(df: pd.DataFrame, references: dict) -> dict:
+def handle_dataframe_delta(df: pd.DataFrame, references: dict, unit_class: str | None = None) -> dict:
     """
     Process delta statistics from DataFrame using pre-fetched references.
 
@@ -188,8 +188,6 @@ def handle_dataframe_delta(df: pd.DataFrame, references: dict) -> dict:
     Args:
     ----
         df: DataFrame with delta column
-        timezone_identifier: User's timezone
-        datetime_format: Datetime format string
         references: Dict mapping statistic_id to reference data:
                    {
                        statistic_id: {
@@ -197,6 +195,7 @@ def handle_dataframe_delta(df: pd.DataFrame, references: dict) -> dict:
                            "ref_type": DeltaReferenceType.OLDER_REFERENCE or DeltaReferenceType.NEWER_REFERENCE
                        } or None
                    }
+        unit_class: Optional unit_class for energy dashboard support
 
     Returns:
     -------
@@ -280,7 +279,7 @@ def handle_dataframe_delta(df: pd.DataFrame, references: dict) -> dict:
             "source": source,
             "statistic_id": statistic_id,
             "name": None,
-            "unit_class": None,
+            "unit_class": unit_class,
             "unit_of_measurement": unit,
         }
 

--- a/custom_components/import_statistics/import_service_delta_helper.py
+++ b/custom_components/import_statistics/import_service_delta_helper.py
@@ -178,7 +178,7 @@ def convert_deltas_with_newer_reference(
     return converted_rows
 
 
-def handle_dataframe_delta(df: pd.DataFrame, references: dict, unit_class: str | None = None) -> dict:
+def handle_dataframe_delta(df: pd.DataFrame, references: dict, unit_class: str | None = None, name: str | None = None) -> dict:
     """
     Process delta statistics from DataFrame using pre-fetched references.
 
@@ -278,7 +278,7 @@ def handle_dataframe_delta(df: pd.DataFrame, references: dict, unit_class: str |
             "has_sum": True,
             "source": source,
             "statistic_id": statistic_id,
-            "name": None,
+            "name": name,
             "unit_class": unit_class,
             "unit_of_measurement": unit,
         }

--- a/custom_components/import_statistics/import_service_helper.py
+++ b/custom_components/import_statistics/import_service_helper.py
@@ -341,7 +341,7 @@ def handle_arguments(call: ServiceCall, ha_timezone: str, *, filename: str | Non
     return decimal, timezone_identifier, delimiter, datetime_format, unit_class
 
 
-def handle_dataframe_no_delta(df: pd.DataFrame, unit_class: str | None = None) -> dict:
+def handle_dataframe_no_delta(df: pd.DataFrame, unit_class: str | None = None, name: str | None = None) -> dict:
     """
     Process non-delta statistics from DataFrame.
 
@@ -349,6 +349,7 @@ def handle_dataframe_no_delta(df: pd.DataFrame, unit_class: str | None = None) -
     ----
         df: DataFrame with statistic_id, start, and value columns
         unit_class: Optional unit_class for energy dashboard support
+        name: Optional display name applied to all statistics in the DataFrame
 
     Returns:
     -------
@@ -396,8 +397,8 @@ def handle_dataframe_no_delta(df: pd.DataFrame, unit_class: str | None = None) -
 
     for statistic_id in unique_ids:
         # Get unit from first occurrence of this statistic_id
-        unit_series = df.loc[df["statistic_id"] == statistic_id, "unit"]
-        unit: str = unit_series.iloc[0]  # type: ignore[assignment]
+        first_row = df.loc[df["statistic_id"] == statistic_id].iloc[0]
+        unit: str = first_row["unit"]  # type: ignore[assignment]
         source = helpers.get_source(statistic_id)
 
         metadata = {
@@ -405,7 +406,7 @@ def handle_dataframe_no_delta(df: pd.DataFrame, unit_class: str | None = None) -
             "has_sum": has_sum,
             "source": source,
             "statistic_id": statistic_id,
-            "name": None,
+            "name": name,
             "unit_class": unit_class,
             "unit_of_measurement": helpers.get_unit_from_row(unit, statistic_id),
         }

--- a/custom_components/import_statistics/import_service_helper.py
+++ b/custom_components/import_statistics/import_service_helper.py
@@ -19,6 +19,7 @@ from custom_components.import_statistics.const import (
     ATTR_DECIMAL,
     ATTR_DELIMITER,
     ATTR_TIMEZONE_IDENTIFIER,
+    ATTR_UNIT_CLASS,
     DATETIME_DEFAULT_FORMAT,
 )
 from custom_components.import_statistics.helpers import _LOGGER
@@ -127,7 +128,7 @@ def prepare_data_to_import(file_path: str, call: ServiceCall, ha_timezone: str) 
 
     Returns:
     -------
-        Tuple of (df, timezone_identifier, datetime_format, is_delta)
+        Tuple of (df, timezone_identifier, datetime_format, is_delta, unit_class)
 
     Raises:
     ------
@@ -139,7 +140,7 @@ def prepare_data_to_import(file_path: str, call: ServiceCall, ha_timezone: str) 
     if file_suffix not in {".csv", ".tsv"}:
         helpers.handle_error(f"Unsupported filename extension for {Path(file_path).name!r}. Supported extensions: .csv, .tsv")
 
-    decimal, timezone_identifier, delimiter, datetime_format = handle_arguments(call, ha_timezone, filename=Path(file_path).name)
+    decimal, timezone_identifier, delimiter, datetime_format, unit_class = handle_arguments(call, ha_timezone, filename=Path(file_path).name)
 
     _LOGGER.info("Importing statistics from file: %s", file_path)
     if not Path(file_path).exists():
@@ -175,7 +176,7 @@ def prepare_data_to_import(file_path: str, call: ServiceCall, ha_timezone: str) 
 
     is_delta = _validate_and_detect_delta(my_df)
 
-    return my_df, timezone_identifier, datetime_format, is_delta
+    return my_df, timezone_identifier, datetime_format, is_delta, unit_class
 
 
 def prepare_json_data_to_import(call: ServiceCall, ha_timezone: str) -> tuple:
@@ -189,14 +190,14 @@ def prepare_json_data_to_import(call: ServiceCall, ha_timezone: str) -> tuple:
 
     Returns:
     -------
-        Tuple of (df, timezone_identifier, datetime_format, is_delta)
+        Tuple of (df, timezone_identifier, datetime_format, is_delta, unit_class)
 
     Raises:
     ------
         HomeAssistantError: If there is a validation error.
 
     """
-    _, timezone_identifier, _, datetime_format = handle_arguments(call, ha_timezone, filename=None)
+    _, timezone_identifier, _, datetime_format, unit_class = handle_arguments(call, ha_timezone, filename=None)
 
     # Required columns that are always present
     required_columns = ["statistic_id", "unit", "start"]
@@ -268,7 +269,7 @@ def prepare_json_data_to_import(call: ServiceCall, ha_timezone: str) -> tuple:
 
     is_delta = _validate_and_detect_delta(my_df)
 
-    return my_df, timezone_identifier, datetime_format, is_delta
+    return my_df, timezone_identifier, datetime_format, is_delta, unit_class
 
 
 def handle_arguments(call: ServiceCall, ha_timezone: str, *, filename: str | None = None) -> tuple:
@@ -283,7 +284,7 @@ def handle_arguments(call: ServiceCall, ha_timezone: str, *, filename: str | Non
 
     Returns:
     -------
-        tuple: A tuple containing the decimal separator, timezone identifier, and delimiter.
+        tuple: A tuple containing the decimal separator, timezone identifier, delimiter, datetime_format, and unit_class.
 
     Raises:
     ------
@@ -328,23 +329,26 @@ def handle_arguments(call: ServiceCall, ha_timezone: str, *, filename: str | Non
 
     delimiter = helpers.validate_delimiter(delimiter_raw)
 
+    # Get unit_class from service call (optional, defaults to None)
+    unit_class = call.data.get(ATTR_UNIT_CLASS)
+
     _LOGGER.debug("Timezone_identifier: %s", timezone_identifier)
     _LOGGER.debug("Delimiter: %s", delimiter)
     _LOGGER.debug("Decimal separator: %s", decimal)
     _LOGGER.debug("Datetime format: %s", datetime_format)
+    _LOGGER.debug("Unit class: %s", unit_class)
 
-    return decimal, timezone_identifier, delimiter, datetime_format
+    return decimal, timezone_identifier, delimiter, datetime_format, unit_class
 
 
-def handle_dataframe_no_delta(df: pd.DataFrame) -> dict:
+def handle_dataframe_no_delta(df: pd.DataFrame, unit_class: str | None = None) -> dict:
     """
     Process non-delta statistics from DataFrame.
 
     Args:
     ----
         df: DataFrame with statistic_id, start, and value columns
-        timezone_identifier: IANA timezone string
-        datetime_format: Format string for parsing timestamps
+        unit_class: Optional unit_class for energy dashboard support
 
     Returns:
     -------
@@ -402,7 +406,7 @@ def handle_dataframe_no_delta(df: pd.DataFrame) -> dict:
             "source": source,
             "statistic_id": statistic_id,
             "name": None,
-            "unit_class": None,
+            "unit_class": unit_class,
             "unit_of_measurement": helpers.get_unit_from_row(unit, statistic_id),
         }
         stats[statistic_id] = (metadata, [])

--- a/custom_components/import_statistics/services.yaml
+++ b/custom_components/import_statistics/services.yaml
@@ -8,6 +8,12 @@ import_from_file:
       selector:
         text:
 
+    name:
+      required: false
+      example: "Energy Provider (Gas)"
+      selector:
+        text:
+
     define_import_format:
       collapsed: false
       fields:

--- a/custom_components/import_statistics/services.yaml
+++ b/custom_components/import_statistics/services.yaml
@@ -55,6 +55,32 @@ import_from_file:
           selector:
             text:
 
+    energy_dashboard_settings:
+      collapsed: true
+      fields:
+        unit_class:
+          required: false
+          example: "energy"
+          selector:
+            select:
+              mode: dropdown
+              options:
+                - "energy"
+                - "power"
+                - "volume"
+                - "volume_flow_rate"
+                - "temperature"
+                - "pressure"
+                - "data_rate"
+                - "data_size"
+                - "irradiance"
+                - "humidity"
+                - "precipitation"
+                - "speed"
+                - "signal_strength"
+                - "volatile_organic_substance"
+                - "monetary"
+
 export_statistics:
   fields:
     filename:

--- a/custom_components/import_statistics/translations/en.json
+++ b/custom_components/import_statistics/translations/en.json
@@ -26,6 +26,10 @@
                 "unit_class": {
                     "name": "unit_class",
                     "description": "Optional unit class for Energy Dashboard compatibility. Required for external statistics (with ':' in the ID) to appear in the Energy Dashboard. Common values: 'energy' (kWh), 'volume' (m³), 'power', 'temperature'."
+                },
+                "name": {
+                    "name": "name",
+                    "description": "Optional friendly display name for the statistic, stored in the database and shown by the Home Assistant frontend (Energy Dashboard, Statistics Graph card) for external statistics. Applies to all statistic IDs in the imported file."
                 }
             },
             "name": "Import statistics from file"

--- a/custom_components/import_statistics/translations/en.json
+++ b/custom_components/import_statistics/translations/en.json
@@ -22,6 +22,10 @@
                 "datetime_format": {
                     "name": "datetime_format",
                     "description": "The format of the datetime strings in the imported file. Default is '%d.%m.%Y %H:%M'. d .. day, m .. month, y .. Year, H .. hour, M .. minute"
+                },
+                "unit_class": {
+                    "name": "unit_class",
+                    "description": "Optional unit class for Energy Dashboard compatibility. Required for external statistics (with ':' in the ID) to appear in the Energy Dashboard. Common values: 'energy' (kWh), 'volume' (m³), 'power', 'temperature'."
                 }
             },
             "name": "Import statistics from file"

--- a/docs/user/counters.md
+++ b/docs/user/counters.md
@@ -126,6 +126,28 @@ For more details regarding long term statistics, see
 
 ---
 
+### Energy Dashboard Integration
+
+To use imported external statistics (with `:` in the statistic ID, e.g., `sensor:imported_energy`) in the Energy Dashboard, you must set the `unit_class` parameter during import:
+
+```yaml
+action: import_statistics.import_from_file
+data:
+  filename: electricity_data.csv
+  delimiter: ","
+  decimal: "."
+  unit_class: energy  # Required for Energy Dashboard
+```
+
+Common `unit_class` values for counters:
+- `energy` - For electricity/gas consumption in kWh
+- `volume` - For water consumption in m³
+- `power` - For power measurements in W
+
+Without `unit_class`, external statistics will not appear in the Energy Dashboard dropdown menus.
+
+---
+
 ## Delta Import
 
 Instead of importing absolute `sum`/`state` values, you can import **delta** values (the change per hour). This is useful because you

--- a/tests/unit_tests/test_convert_delta_dataframe_with_references.py
+++ b/tests/unit_tests/test_convert_delta_dataframe_with_references.py
@@ -43,6 +43,7 @@ def test_convert_delta_dataframe_with_references_single_statistic() -> None:
     metadata, stats = result["sensor.temperature"]
     assert metadata["has_sum"] is True
     assert metadata["mean_type"].value == 0  # NONE
+    assert metadata["unit_class"] is None  # Default None
     assert len(stats) == 2
     assert stats[0]["sum"] == 110.5
     assert stats[1]["sum"] == 115.7
@@ -87,11 +88,51 @@ def test_convert_delta_dataframe_with_references_multiple_statistics() -> None:
     _energy_meta, energy_stats = result["sensor.energy"]
     assert len(energy_stats) == 2
     assert energy_stats[0]["sum"] == 110.5
+    assert _energy_meta["unit_class"] is None  # Default None
 
     # Check gas
     _gas_meta, gas_stats = result["sensor.gas"]
     assert len(gas_stats) == 2
     assert gas_stats[0]["sum"] == 51.5
+    assert _gas_meta["unit_class"] is None  # Default None
+
+
+def test_convert_delta_dataframe_with_unit_class_energy() -> None:
+    """Test handle_dataframe_delta with unit_class set to energy."""
+    tz_id = "Europe/Vienna"
+    tz = zoneinfo.ZoneInfo(tz_id)
+    datetime_format = "%d.%m.%Y %H:%M"
+
+    df = pd.DataFrame(
+        {
+            "statistic_id": ["sensor:external_energy", "sensor:external_energy"],
+            "start": ["01.01.2022 00:00", "01.01.2022 01:00"],
+            "delta": [10.5, 5.2],
+            "unit": ["kWh", "kWh"],
+        }
+    )
+
+    # Parse timestamps (simulating what prepare_data_to_import does)
+    df["start"] = pd.to_datetime(df["start"], format=datetime_format).dt.tz_localize(tz)
+
+    references = {
+        "sensor:external_energy": {
+            "reference": {"start": dt.datetime(2021, 12, 31, 23, 0, tzinfo=tz), "sum": 100.0, "state": 100.0},
+            "ref_type": DeltaReferenceType.OLDER_REFERENCE,
+        }
+    }
+
+    result = handle_dataframe_delta(df, references, unit_class="energy")
+
+    assert len(result) == 1
+    assert "sensor:external_energy" in result
+    metadata, stats = result["sensor:external_energy"]
+    assert metadata["has_sum"] is True
+    assert metadata["mean_type"].value == 0  # NONE
+    assert metadata["unit_class"] == "energy"  # Set to energy
+    assert len(stats) == 2
+    assert stats[0]["sum"] == 110.5
+    assert stats[1]["sum"] == 115.7
 
 
 def test_convert_delta_dataframe_with_references_missing_reference() -> None:

--- a/tests/unit_tests/test_statistic_name.py
+++ b/tests/unit_tests/test_statistic_name.py
@@ -1,0 +1,77 @@
+"""Tests for the optional 'name' service parameter support in import."""
+
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+from homeassistant.components.recorder.models import StatisticMeanType
+
+from custom_components.import_statistics.import_service_helper import handle_dataframe_no_delta
+
+
+TZ_UTC = ZoneInfo("UTC")
+
+
+def _make_df_sum(rows: list, tz: ZoneInfo = TZ_UTC) -> pd.DataFrame:
+    df = pd.DataFrame(rows, columns=["statistic_id", "start", "unit", "sum"])
+    df["start"] = df["start"].apply(lambda v: pd.to_datetime(v, format="%d.%m.%Y %H:%M").tz_localize(tz))
+    return df
+
+
+# ---------------------------------------------------------------------------
+# handle_dataframe_no_delta — name parameter propagation
+# ---------------------------------------------------------------------------
+
+
+def test_name_parameter_set_in_metadata() -> None:
+    """name parameter is stored in metadata for all statistic_ids."""
+    df = _make_df_sum([["my:stat", "01.01.2022 00:00", "kWh", 100.0]])
+
+    stats = handle_dataframe_no_delta(df, name="Stadtwerke Strom")
+
+    assert stats["my:stat"][0]["name"] == "Stadtwerke Strom"
+
+
+def test_no_name_parameter_gives_none() -> None:
+    """When name parameter is omitted, metadata.name is None."""
+    df = _make_df_sum([["my:stat", "01.01.2022 00:00", "kWh", 100.0]])
+
+    stats = handle_dataframe_no_delta(df)
+
+    assert stats["my:stat"][0]["name"] is None
+
+
+def test_name_none_gives_none() -> None:
+    """When name=None is passed explicitly, metadata.name is None."""
+    df = _make_df_sum([["my:stat", "01.01.2022 00:00", "kWh", 100.0]])
+
+    stats = handle_dataframe_no_delta(df, name=None)
+
+    assert stats["my:stat"][0]["name"] is None
+
+
+def test_name_applied_to_all_statistic_ids() -> None:
+    """name parameter applies to all statistic_ids in the file."""
+    df = _make_df_sum([
+        ["my:stat1", "01.01.2022 00:00", "kWh", 10.0],
+        ["my:stat2", "01.01.2022 00:00", "kWh", 20.0],
+    ])
+
+    stats = handle_dataframe_no_delta(df, name="Shared Name")
+
+    assert stats["my:stat1"][0]["name"] == "Shared Name"
+    assert stats["my:stat2"][0]["name"] == "Shared Name"
+
+
+def test_name_with_mean_type() -> None:
+    """name parameter works with mean/min/max data type."""
+    df = pd.DataFrame(
+        [["my:sensor", "01.01.2022 00:00", "°C", 18.0, 22.0, 20.0]],
+        columns=["statistic_id", "start", "unit", "min", "max", "mean"],
+    )
+    df["start"] = df["start"].apply(lambda v: pd.to_datetime(v, format="%d.%m.%Y %H:%M").tz_localize(TZ_UTC))
+
+    stats = handle_dataframe_no_delta(df, name="Living Room Temp")
+
+    metadata = stats["my:sensor"][0]
+    assert metadata["name"] == "Living Room Temp"
+    assert metadata["mean_type"] == StatisticMeanType.ARITHMETIC

--- a/tests/unit_tests/test_unit_class.py
+++ b/tests/unit_tests/test_unit_class.py
@@ -27,7 +27,7 @@ def test_unit_class_present_in_metadata_mean() -> None:
     # Parse timestamps (simulating what prepare_data_to_import does)
     my_df["start"] = pd.to_datetime(my_df["start"], format=DATETIME_DEFAULT_FORMAT).dt.tz_localize(ZoneInfo("UTC"))
 
-    # Call the function
+    # Call the function without unit_class (default None)
     stats = handle_dataframe_no_delta(my_df)
 
     # Get the metadata for the statistic
@@ -66,7 +66,7 @@ def test_unit_class_present_in_metadata_sum() -> None:
     # Parse timestamps (simulating what prepare_data_to_import does)
     my_df["start"] = pd.to_datetime(my_df["start"], format=DATETIME_DEFAULT_FORMAT).dt.tz_localize(ZoneInfo("UTC"))
 
-    # Call the function
+    # Call the function without unit_class (default None)
     stats = handle_dataframe_no_delta(my_df)
 
     # Get the metadata for the statistic
@@ -107,7 +107,7 @@ def test_unit_class_multiple_statistics() -> None:
     # Parse timestamps (simulating what prepare_data_to_import does)
     my_df["start"] = pd.to_datetime(my_df["start"], format=DATETIME_DEFAULT_FORMAT).dt.tz_localize(ZoneInfo("UTC"))
 
-    # Call the function
+    # Call the function without unit_class (default None)
     stats = handle_dataframe_no_delta(my_df)
 
     # Verify all statistics have unit_class set to None
@@ -116,3 +116,77 @@ def test_unit_class_multiple_statistics() -> None:
         metadata = stats[stat_id][0]
         assert "unit_class" in metadata, f"unit_class field is missing for {stat_id}"
         assert metadata["unit_class"] is None, f"unit_class should be None for {stat_id}, got {metadata['unit_class']}"
+
+
+def test_unit_class_set_to_energy() -> None:
+    """
+    Test that unit_class field is set to "energy" when provided.
+
+    This test verifies that the unit_class field is properly set to "energy"
+    when the unit_class parameter is provided, which is needed for energy dashboard support.
+    """
+    # Create a sample dataframe with 'sum' (energy data)
+    my_df = pd.DataFrame(
+        [
+            ["sensor:external_energy", "01.01.2022 00:00", "kWh", 100],
+        ],
+        columns=["statistic_id", "start", "unit", "sum"],
+    )
+
+    # Parse timestamps (simulating what prepare_data_to_import does)
+    my_df["start"] = pd.to_datetime(my_df["start"], format=DATETIME_DEFAULT_FORMAT).dt.tz_localize(ZoneInfo("UTC"))
+
+    # Call the function with unit_class set to "energy"
+    stats = handle_dataframe_no_delta(my_df, unit_class="energy")
+
+    # Get the metadata for the statistic
+    metadata = stats["sensor:external_energy"][0]
+
+    # Verify unit_class is present and set to "energy"
+    assert "unit_class" in metadata, "unit_class field is missing from metadata"
+    assert metadata["unit_class"] == "energy", f"unit_class should be 'energy', got {metadata['unit_class']}"
+
+    # Verify other expected fields are present
+    assert metadata["mean_type"] == StatisticMeanType.NONE
+    assert metadata["has_sum"] is True
+    assert metadata["statistic_id"] == "sensor:external_energy"
+    assert metadata["source"] == "sensor"  # External statistics use domain as source
+    assert metadata["unit_of_measurement"] == "kWh"
+    assert metadata["name"] is None
+
+
+def test_unit_class_set_to_power() -> None:
+    """
+    Test that unit_class field is set to "power" when provided.
+
+    This test verifies that the unit_class field is properly set to "power"
+    when the unit_class parameter is provided.
+    """
+    # Create a sample dataframe with 'mean' (power data)
+    my_df = pd.DataFrame(
+        [
+            ["sensor:external_power", "01.01.2022 00:00", "W", 10, 500, 250],
+        ],
+        columns=["statistic_id", "start", "unit", "min", "max", "mean"],
+    )
+
+    # Parse timestamps (simulating what prepare_data_to_import does)
+    my_df["start"] = pd.to_datetime(my_df["start"], format=DATETIME_DEFAULT_FORMAT).dt.tz_localize(ZoneInfo("UTC"))
+
+    # Call the function with unit_class set to "power"
+    stats = handle_dataframe_no_delta(my_df, unit_class="power")
+
+    # Get the metadata for the statistic
+    metadata = stats["sensor:external_power"][0]
+
+    # Verify unit_class is present and set to "power"
+    assert "unit_class" in metadata, "unit_class field is missing from metadata"
+    assert metadata["unit_class"] == "power", f"unit_class should be 'power', got {metadata['unit_class']}"
+
+    # Verify other expected fields are present
+    assert metadata["mean_type"] == StatisticMeanType.ARITHMETIC
+    assert metadata["has_sum"] is False
+    assert metadata["statistic_id"] == "sensor:external_power"
+    assert metadata["source"] == "sensor"
+    assert metadata["unit_of_measurement"] == "W"
+    assert metadata["name"] is None


### PR DESCRIPTION
- [ ] Make sure to first merge https://github.com/klausj1/homeassistant-statistics/pull/230

## Summary
 
Adds an optional `name` parameter to `import_from_file` and `import_from_json` services.
When provided, the name is stored in `statistics_meta.name` and displayed by the HA
frontend for external statistics (Energy Dashboard, Statistics Graph card).

**Adding the statistics**:
<img width="231" height="152" alt="image" src="https://github.com/user-attachments/assets/34a6b325-545a-4091-ab34-1e8c14cdba35" />

**Visualization**:
<img width="525" height="333" alt="image" src="https://github.com/user-attachments/assets/104ca7db-f53b-4a79-8324-fe427a2d9766" />
 
## Usage
 
action: import_statistics.import_from_file
data:
-  `filename`: `data/electricity.csv`
-  `name`: `Stadtwerke Strom`
-  `unit_class`: `energy`
 
The name applies to all statistic_ids in the file. Re-importing updates it immediately
(upsert semantics — no deletion required).
 
## Changes
- import_service.py: read `name` from call.data, add to PreparedImportData, pass through
- import_service_helper.py: handle_dataframe_no_delta() accepts name parameter
- import_service_delta_helper.py: handle_dataframe_delta() accepts name parameter
- services.yaml: documents name as optional field for import_from_file
- tests/unit_tests/test_statistic_name.py: new tests for name parameter propagation