### PR TITLE
add optional service response to import services

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,73 @@ Only these columns are accepted (unknown columns cause an error):
 
 > If importing does not work and you do not get an error directly in the GUI, but there is an error in the Home Assistant logs, then this is a bug. This happens if the integration misses some checks, which lead to import errors later. Please create an issue.
 
+### Service Response
+
+`import_from_file` and `import_from_json` can optionally return information about whether each imported statistic actually received new data. To receive a response, set `response_variable` in your automation or script.
+
+```yaml
+- action: import_statistics.import_from_file
+  data:
+    filename: my_statistics.csv
+    delimiter: ","
+    decimal: "."
+    datetime_format: "%Y-%m-%d %H:%M"
+  response_variable: import_result
+```
+
+The response is a JSON-serializable dict:
+
+```json
+{
+  "results": {
+    "sensor:imported_energy": {
+      "statistic_id": "sensor:imported_energy",
+      "has_new_data": true,
+      "newest_import_start": "2026-08-17T23:00:00+00:00",
+      "newest_db_start": "2026-08-16T23:00:00+00:00"
+    }
+  }
+}
+```
+
+Use the response in any action. This example creates a persistent notification if no new data got imported:
+
+```yaml
+- choose:
+    - conditions:
+        - condition: template
+          value_template: >-
+            {{ not import_result.results['sensor:imported_energy'].has_new_data }}
+      sequence:
+        - service: persistent_notification.create
+          data:
+            title: "Import Error"
+            message: "No new data for sensor:imported_energy!"
+```
+
+
+You can also list all statistics that had no new data in a single notification:
+
+```yaml
+- service: persistent_notification.create
+  data:
+    title: "Statistics without new data"
+    message: >
+      {% set no_new_ids = [] %}
+      {% for info in import_result.results.values() %}
+        {% if not info.has_new_data %}
+          {% set no_new_ids = no_new_ids + [info.statistic_id] %}
+        {% endif %}
+      {% endfor %}
+      {% if no_new_ids %}
+        No new data for: {{ no_new_ids | join(', ') }}
+      {% else %}
+        All imported statistics contain new data.
+      {% endif %}
+```
+
+> **Note:** The response variable is only populated when the action is called with `response_variable`. Without it the action behaves as before and returns no response.
+
 ### Data Validation
 
 The integration performs strict validation on all import data:

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Only these columns are accepted (unknown columns cause an error):
 
 ### Service Response
 
-`import_from_file` and `import_from_json` can optionally return information about whether each imported statistic actually received new data. To receive a response, set `response_variable` in your automation or script.
+`import_from_file` and `import_from_json` can optionally return an import `status` for each statistic. To receive a response, set `response_variable` in your automation or script.
 
 ```yaml
 - action: import_statistics.import_from_file
@@ -233,7 +233,7 @@ The response is a JSON-serializable dict:
   "results": {
     "sensor:imported_energy": {
       "statistic_id": "sensor:imported_energy",
-      "has_new_data": true,
+      "status": "<see below>",
       "newest_import_start": "2026-08-17T23:00:00+00:00",
       "newest_db_start": "2026-08-16T23:00:00+00:00"
     }
@@ -241,18 +241,23 @@ The response is a JSON-serializable dict:
 }
 ```
 
-Use the response in any action. This example creates a persistent notification if no new data got imported:
+> **Note:** The response includes a `status` field for each statistic. The possible values are:
+> - `new data` — the newest start timestamp in the import is newer than the newest timestamp in the database.
+> - `existing data` — the import only overwrites existing timestamps or adds older/equal timestamps (still saved, but no new timestamp is added).
+> - `no data` — no rows were provided for this statistic, so nothing is imported.
+
+Use the response in any action. This example creates a persistent notification if no newer data was found in the import:
 
 ```yaml
 - choose:
     - conditions:
         - condition: template
           value_template: >-
-            {{ not import_result.results['sensor:imported_energy'].has_new_data }}
+            {{ import_result.results['sensor:imported_energy'].status != 'new data' }}
       sequence:
         - service: persistent_notification.create
           data:
-            title: "Import Error"
+            title: "No new data"
             message: "No new data for sensor:imported_energy!"
 ```
 
@@ -266,7 +271,7 @@ You can also list all statistics that had no new data in a single notification:
     message: >
       {% set no_new_ids = [] %}
       {% for info in import_result.results.values() %}
-        {% if not info.has_new_data %}
+        {% if info.status != 'new data' %}
           {% set no_new_ids = no_new_ids + [info.statistic_id] %}
         {% endif %}
       {% endfor %}

--- a/custom_components/import_statistics/__init__.py
+++ b/custom_components/import_statistics/__init__.py
@@ -1,7 +1,7 @@
 """The import_statistics integration."""
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
@@ -38,25 +38,27 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # pylin
 
     """
 
-    async def handle_import_from_file(call: ServiceCall) -> None:
+    async def handle_import_from_file(call: ServiceCall) -> ServiceResponse:
         """Handle the service call."""
-        await handle_import_from_file_impl(hass, call)
+        return await handle_import_from_file_impl(hass, call)
 
     hass.services.async_register(
         DOMAIN,
         "import_from_file",
         handle_import_from_file,
+        supports_response=SupportsResponse.OPTIONAL,
         description_placeholders={"pytz_url": "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"},
     )
 
-    async def handle_import_from_json(call: ServiceCall) -> None:
+    async def handle_import_from_json(call: ServiceCall) -> ServiceResponse:
         """Handle the json service call."""
-        await handle_import_from_json_impl(hass, call)
+        return await handle_import_from_json_impl(hass, call)
 
     hass.services.async_register(
         DOMAIN,
         "import_from_json",
         handle_import_from_json,
+        supports_response=SupportsResponse.OPTIONAL,
         description_placeholders={
             "json_example_url": "https://github.com/klausj1/homeassistant-statistics/blob/main/assets/state_sum.json",
         },

--- a/custom_components/import_statistics/import_service.py
+++ b/custom_components/import_statistics/import_service.py
@@ -267,7 +267,7 @@ async def import_stats(hass: HomeAssistant, stats: dict) -> dict:
     _LOGGER.info("Validating entities and units")
     await validate_entities_and_units(hass, stats)
 
-    # Determine whether each statistic will actually receive new data
+    # Determine the import status for each statistic before writing
     results: dict[str, dict] = {}
     _LOGGER.info("Checking for new data before import")
     for stat in stats.values():
@@ -279,23 +279,23 @@ async def import_stats(hass: HomeAssistant, stats: dict) -> dict:
         newest_db_start = newest_db_record["start"] if newest_db_record else None
 
         newest_import_start = None
-        has_new_data = True  # Assume new if no DB record exists
+        status = "no data"
         if statistics:
             newest_import_start = max(s["start"].astimezone(dt.UTC) for s in statistics)
-            has_new_data = newest_db_start is None or newest_import_start > newest_db_start
+            status = "new data" if (newest_db_start is None or newest_import_start > newest_db_start) else "existing data"
 
         results[statistic_id] = {
             "statistic_id": statistic_id,
-            "has_new_data": has_new_data,
+            "status": status,
             "newest_import_start": newest_import_start.isoformat() if newest_import_start else None,
             "newest_db_start": newest_db_start.isoformat() if newest_db_start else None,
         }
         _LOGGER.debug(
-            "Statistic %s: newest_db=%s, newest_import=%s, has_new_data=%s",
+            "Statistic %s: newest_db=%s, newest_import=%s, status=%s",
             statistic_id,
             newest_db_start,
             newest_import_start,
-            has_new_data,
+            status,
         )
 
     _LOGGER.info("Calling hass import methods")

--- a/custom_components/import_statistics/import_service.py
+++ b/custom_components/import_statistics/import_service.py
@@ -19,6 +19,7 @@ from custom_components.import_statistics.helpers import _LOGGER, DeltaReferenceT
 from custom_components.import_statistics.import_service_delta_helper import handle_dataframe_delta
 from custom_components.import_statistics.import_service_helper import (
     ImportDataType,
+    get_import_status_for_statistic,
     handle_dataframe_mixed,
     handle_dataframe_no_delta,
     prepare_data_to_import,
@@ -278,24 +279,14 @@ async def import_stats(hass: HomeAssistant, stats: dict) -> dict:
         newest_db_record = await _get_newest_db_statistic(hass, statistic_id)
         newest_db_start = newest_db_record["start"] if newest_db_record else None
 
-        newest_import_start = None
-        status = "no data"
-        if statistics:
-            newest_import_start = max(s["start"].astimezone(dt.UTC) for s in statistics)
-            status = "new data" if (newest_db_start is None or newest_import_start > newest_db_start) else "existing data"
-
-        results[statistic_id] = {
-            "statistic_id": statistic_id,
-            "status": status,
-            "newest_import_start": newest_import_start.isoformat() if newest_import_start else None,
-            "newest_db_start": newest_db_start.isoformat() if newest_db_start else None,
-        }
+        result_entry = get_import_status_for_statistic(statistic_id, statistics, newest_db_start)
+        results[statistic_id] = result_entry
         _LOGGER.debug(
             "Statistic %s: newest_db=%s, newest_import=%s, status=%s",
             statistic_id,
             newest_db_start,
-            newest_import_start,
-            status,
+            result_entry["newest_import_start"],
+            result_entry["status"],
         )
 
     _LOGGER.info("Calling hass import methods")

--- a/custom_components/import_statistics/import_service.py
+++ b/custom_components/import_statistics/import_service.py
@@ -207,7 +207,7 @@ class PreparedImportData:
     data_type: Any
 
 
-async def _process_import(hass: HomeAssistant, data: PreparedImportData) -> None:
+async def _process_import(hass: HomeAssistant, data: PreparedImportData) -> dict:
     """
     Process import after DataFrame is prepared.
 
@@ -230,10 +230,10 @@ async def _process_import(hass: HomeAssistant, data: PreparedImportData) -> None
         _LOGGER.info("Non-delta mode, processing directly")
         stats = await hass.async_add_executor_job(lambda: handle_dataframe_no_delta(data.df))
 
-    await import_stats(hass, stats)
+    return await import_stats(hass, stats)
 
 
-async def handle_import_from_file_impl(hass: HomeAssistant, call: ServiceCall) -> None:
+async def handle_import_from_file_impl(hass: HomeAssistant, call: ServiceCall) -> dict:
     """Handle import_from_file service implementation."""
     _LOGGER.info("Service handle_import_from_file called")
     file_path = f"{hass.config.config_dir}/{call.data.get(ATTR_FILENAME)}"
@@ -246,10 +246,10 @@ async def handle_import_from_file_impl(hass: HomeAssistant, call: ServiceCall) -
     _LOGGER.info("Preparing data for import ...")
     df, timezone_id, datetime_format, data_type = await hass.async_add_executor_job(lambda: prepare_data_to_import(file_path, call, ha_timezone))
 
-    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, data_type))
+    return await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, data_type))
 
 
-async def handle_import_from_json_impl(hass: HomeAssistant, call: ServiceCall) -> None:
+async def handle_import_from_json_impl(hass: HomeAssistant, call: ServiceCall) -> dict:
     """Handle import_from_json service implementation."""
     _LOGGER.info("Service handle_import_from_json called")
 
@@ -259,13 +259,44 @@ async def handle_import_from_json_impl(hass: HomeAssistant, call: ServiceCall) -
     _LOGGER.info("Preparing data for import")
     df, timezone_id, datetime_format, data_type = await hass.async_add_executor_job(lambda: prepare_json_data_to_import(call, ha_timezone))
 
-    await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, data_type))
+    return await _process_import(hass, PreparedImportData(df, timezone_id, datetime_format, data_type))
 
 
-async def import_stats(hass: HomeAssistant, stats: dict) -> None:
+async def import_stats(hass: HomeAssistant, stats: dict) -> dict:
     """Import statistics into Home Assistant and wait for recorder to commit."""
     _LOGGER.info("Validating entities and units")
     await validate_entities_and_units(hass, stats)
+
+    # Determine whether each statistic will actually receive new data
+    results: dict[str, dict] = {}
+    _LOGGER.info("Checking for new data before import")
+    for stat in stats.values():
+        metadata = stat[0]
+        statistics = stat[1]
+        statistic_id = metadata["statistic_id"]
+
+        newest_db_record = await _get_newest_db_statistic(hass, statistic_id)
+        newest_db_start = newest_db_record["start"] if newest_db_record else None
+
+        newest_import_start = None
+        has_new_data = True  # Assume new if no DB record exists
+        if statistics:
+            newest_import_start = max(s["start"].astimezone(dt.UTC) for s in statistics)
+            has_new_data = newest_db_start is None or newest_import_start > newest_db_start
+
+        results[statistic_id] = {
+            "statistic_id": statistic_id,
+            "has_new_data": has_new_data,
+            "newest_import_start": newest_import_start.isoformat() if newest_import_start else None,
+            "newest_db_start": newest_db_start.isoformat() if newest_db_start else None,
+        }
+        _LOGGER.debug(
+            "Statistic %s: newest_db=%s, newest_import=%s, has_new_data=%s",
+            statistic_id,
+            newest_db_start,
+            newest_import_start,
+            has_new_data,
+        )
 
     _LOGGER.info("Calling hass import methods")
     for stat in stats.values():
@@ -287,6 +318,8 @@ async def import_stats(hass: HomeAssistant, stats: dict) -> None:
     _LOGGER.info("Waiting for recorder to commit imported statistics to database")
     await get_instance(hass).async_block_till_done()
     _LOGGER.info("Finished importing data - all statistics committed to database")
+
+    return {"results": results}
 
 
 async def validate_entities_and_units(hass: HomeAssistant, stats: dict) -> None:

--- a/custom_components/import_statistics/import_service.py
+++ b/custom_components/import_statistics/import_service.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.recorder import get_instance
 
 from custom_components.import_statistics.const import ATTR_FILENAME
 from custom_components.import_statistics.delta_database_access import (
+    _get_newest_db_statistic,
     _get_reference_at_or_after_timestamp,
     _get_reference_before_timestamp,
 )

--- a/custom_components/import_statistics/import_service.py
+++ b/custom_components/import_statistics/import_service.py
@@ -11,7 +11,6 @@ from homeassistant.helpers.recorder import get_instance
 
 from custom_components.import_statistics.const import ATTR_FILENAME
 from custom_components.import_statistics.delta_database_access import (
-    _get_newest_db_statistic,
     _get_reference_at_or_after_timestamp,
     _get_reference_before_timestamp,
 )
@@ -19,7 +18,7 @@ from custom_components.import_statistics.helpers import _LOGGER, DeltaReferenceT
 from custom_components.import_statistics.import_service_delta_helper import handle_dataframe_delta
 from custom_components.import_statistics.import_service_helper import (
     ImportDataType,
-    get_import_status_for_statistic,
+    get_import_status_for_all_statistics,
     handle_dataframe_mixed,
     handle_dataframe_no_delta,
     prepare_data_to_import,
@@ -269,25 +268,7 @@ async def import_stats(hass: HomeAssistant, stats: dict) -> dict:
     await validate_entities_and_units(hass, stats)
 
     # Determine the import status for each statistic before writing
-    results: dict[str, dict] = {}
-    _LOGGER.info("Checking for new data before import")
-    for stat in stats.values():
-        metadata = stat[0]
-        statistics = stat[1]
-        statistic_id = metadata["statistic_id"]
-
-        newest_db_record = await _get_newest_db_statistic(hass, statistic_id)
-        newest_db_start = newest_db_record["start"] if newest_db_record else None
-
-        result_entry = get_import_status_for_statistic(statistic_id, statistics, newest_db_start)
-        results[statistic_id] = result_entry
-        _LOGGER.debug(
-            "Statistic %s: newest_db=%s, newest_import=%s, status=%s",
-            statistic_id,
-            newest_db_start,
-            result_entry["newest_import_start"],
-            result_entry["status"],
-        )
+    results = await get_import_status_for_all_statistics(hass, stats)
 
     _LOGGER.info("Calling hass import methods")
     for stat in stats.values():

--- a/custom_components/import_statistics/import_service_helper.py
+++ b/custom_components/import_statistics/import_service_helper.py
@@ -4,6 +4,8 @@ Helper functions for import service - data preparation from files/JSON.
 No hass object needed.
 """
 
+import datetime as dt
+
 import zoneinfo
 from enum import Enum
 from pathlib import Path
@@ -557,3 +559,36 @@ def handle_dataframe_no_delta(df: pd.DataFrame) -> dict:
         stats[statistic_id][1].extend(statistics_list)
 
     return stats
+
+
+def get_import_status_for_statistic(
+    statistic_id: str,
+    statistics: list[dict],
+    newest_db_start: dt.datetime | None,
+) -> dict:
+    """
+    Determine the import status for a single statistic and build the response entry.
+
+    Args:
+    ----
+        statistic_id: The statistic identifier
+        statistics: List of statistic rows, each containing a 'start' datetime
+        newest_db_start: The newest start timestamp already in the database, or None
+
+    Returns:
+    -------
+        Dictionary with statistic_id, status, newest_import_start and newest_db_start.
+        Timestamps are returned as ISO-formatted strings, or None when not available.
+    """
+    newest_import_start: dt.datetime | None = None
+    status = "no data"
+    if statistics:
+        newest_import_start = max(s["start"].astimezone(dt.UTC) for s in statistics)
+        status = "new data" if (newest_db_start is None or newest_import_start > newest_db_start) else "existing data"
+
+    return {
+        "statistic_id": statistic_id,
+        "status": status,
+        "newest_import_start": newest_import_start.isoformat() if newest_import_start else None,
+        "newest_db_start": newest_db_start.isoformat() if newest_db_start else None,
+    }

--- a/custom_components/import_statistics/import_service_helper.py
+++ b/custom_components/import_statistics/import_service_helper.py
@@ -1,7 +1,7 @@
 """
 Helper functions for import service - data preparation from files/JSON.
 
-No hass object needed.
+Most helpers do not need a hass object; status helpers use the hass object for database lookups.
 """
 
 import datetime as dt
@@ -13,10 +13,12 @@ from pathlib import Path
 import pandas as pd
 import pytz
 from homeassistant.components.recorder.models import StatisticMeanType
-from homeassistant.core import ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.import_statistics import helpers
+from custom_components.import_statistics.delta_database_access import _get_newest_db_statistic
+
 from custom_components.import_statistics.const import (
     ATTR_DATETIME_FORMAT,
     ATTR_DECIMAL,
@@ -592,3 +594,33 @@ def get_import_status_for_statistic(
         "newest_import_start": newest_import_start.isoformat() if newest_import_start else None,
         "newest_db_start": newest_db_start.isoformat() if newest_db_start else None,
     }
+
+
+async def get_import_status_for_all_statistics(hass: HomeAssistant, stats: dict) -> dict:
+    """
+    Determine the import status for every statistic before writing.
+
+    Returns a dictionary keyed by statistic_id, with the same entries as
+    get_import_status_for_statistic.
+    """
+    results: dict[str, dict] = {}
+    _LOGGER.info("Checking for new data before import")
+    for stat in stats.values():
+        metadata = stat[0]
+        statistics = stat[1]
+        statistic_id = metadata["statistic_id"]
+
+        newest_db_record = await _get_newest_db_statistic(hass, statistic_id)
+        newest_db_start = newest_db_record["start"] if newest_db_record else None
+
+        result_entry = get_import_status_for_statistic(statistic_id, statistics, newest_db_start)
+        results[statistic_id] = result_entry
+        _LOGGER.debug(
+            "Statistic %s: newest_db=%s, newest_import=%s, status=%s",
+            statistic_id,
+            newest_db_start,
+            result_entry["newest_import_start"],
+            result_entry["status"],
+        )
+
+    return results

--- a/custom_components/import_statistics/import_service_helper.py
+++ b/custom_components/import_statistics/import_service_helper.py
@@ -5,7 +5,6 @@ Most helpers do not need a hass object; status helpers use the hass object for d
 """
 
 import datetime as dt
-
 import zoneinfo
 from enum import Enum
 from pathlib import Path
@@ -17,8 +16,6 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.import_statistics import helpers
-from custom_components.import_statistics.delta_database_access import _get_newest_db_statistic
-
 from custom_components.import_statistics.const import (
     ATTR_DATETIME_FORMAT,
     ATTR_DECIMAL,
@@ -26,6 +23,7 @@ from custom_components.import_statistics.const import (
     ATTR_TIMEZONE_IDENTIFIER,
     DATETIME_DEFAULT_FORMAT,
 )
+from custom_components.import_statistics.delta_database_access import _get_newest_db_statistic
 from custom_components.import_statistics.helpers import _LOGGER
 
 
@@ -581,6 +579,7 @@ def get_import_status_for_statistic(
     -------
         Dictionary with statistic_id, status, newest_import_start and newest_db_start.
         Timestamps are returned as ISO-formatted strings, or None when not available.
+
     """
     newest_import_start: dt.datetime | None = None
     status = "no data"

--- a/tests/integration_tests_mock/test_import_service_response.py
+++ b/tests/integration_tests_mock/test_import_service_response.py
@@ -24,7 +24,7 @@ class TestImportServiceResponse:
         with (
             patch("custom_components.import_statistics.import_service.validate_entities_and_units", new=AsyncMock()),
             patch(
-                "custom_components.import_statistics.import_service._get_newest_db_statistic",
+                "custom_components.import_statistics.import_service_helper._get_newest_db_statistic",
                 new=AsyncMock(return_value={"start": db_start}),
             ),
             patch("custom_components.import_statistics.import_service.async_add_external_statistics") as mock_add,
@@ -53,7 +53,7 @@ class TestImportServiceResponse:
         with (
             patch("custom_components.import_statistics.import_service.validate_entities_and_units", new=AsyncMock()),
             patch(
-                "custom_components.import_statistics.import_service._get_newest_db_statistic",
+                "custom_components.import_statistics.import_service_helper._get_newest_db_statistic",
                 new=AsyncMock(return_value={"start": db_start}),
             ),
             patch("custom_components.import_statistics.import_service.async_add_external_statistics") as mock_add,

--- a/tests/integration_tests_mock/test_import_service_response.py
+++ b/tests/integration_tests_mock/test_import_service_response.py
@@ -1,0 +1,70 @@
+"""Mock integration tests for the import statistics service response."""
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.import_statistics.import_service import import_stats
+
+
+class TestImportServiceResponse:
+    """Test that import_stats returns the correct status per statistic."""
+
+    @pytest.mark.asyncio
+    async def test_import_stats_returns_new_data_status(self) -> None:
+        """Test that a newer import is reported as 'new data'."""
+        hass = MagicMock()
+        metadata = {"statistic_id": "custom:energy", "source": "custom"}
+        import_start = dt.datetime(2025, 1, 2, 12, 0, tzinfo=dt.UTC)
+        db_start = dt.datetime(2025, 1, 1, 12, 0, tzinfo=dt.UTC)
+        statistics = [{"start": import_start, "sum": 10.0}]
+        stats = {"custom:energy": (metadata, statistics)}
+
+        with (
+            patch("custom_components.import_statistics.import_service.validate_entities_and_units", new=AsyncMock()),
+            patch(
+                "custom_components.import_statistics.import_service._get_newest_db_statistic",
+                new=AsyncMock(return_value={"start": db_start}),
+            ),
+            patch("custom_components.import_statistics.import_service.async_add_external_statistics") as mock_add,
+            patch(
+                "custom_components.import_statistics.import_service.get_instance",
+                return_value=MagicMock(async_block_till_done=AsyncMock()),
+            ),
+        ):
+            result = await import_stats(hass, stats)
+
+        assert result["results"]["custom:energy"]["status"] == "new data"
+        assert result["results"]["custom:energy"]["newest_import_start"] == "2025-01-02T12:00:00+00:00"
+        assert result["results"]["custom:energy"]["newest_db_start"] == "2025-01-01T12:00:00+00:00"
+        assert mock_add.called
+
+    @pytest.mark.asyncio
+    async def test_import_stats_returns_existing_data_status(self) -> None:
+        """Test that an older/equal import is reported as 'existing data'."""
+        hass = MagicMock()
+        metadata = {"statistic_id": "custom:energy", "source": "custom"}
+        import_start = dt.datetime(2025, 1, 1, 10, 0, tzinfo=dt.UTC)
+        db_start = dt.datetime(2025, 1, 1, 12, 0, tzinfo=dt.UTC)
+        statistics = [{"start": import_start, "sum": 10.0}]
+        stats = {"custom:energy": (metadata, statistics)}
+
+        with (
+            patch("custom_components.import_statistics.import_service.validate_entities_and_units", new=AsyncMock()),
+            patch(
+                "custom_components.import_statistics.import_service._get_newest_db_statistic",
+                new=AsyncMock(return_value={"start": db_start}),
+            ),
+            patch("custom_components.import_statistics.import_service.async_add_external_statistics") as mock_add,
+            patch(
+                "custom_components.import_statistics.import_service.get_instance",
+                return_value=MagicMock(async_block_till_done=AsyncMock()),
+            ),
+        ):
+            result = await import_stats(hass, stats)
+
+        assert result["results"]["custom:energy"]["status"] == "existing data"
+        assert result["results"]["custom:energy"]["newest_import_start"] == "2025-01-01T10:00:00+00:00"
+        assert result["results"]["custom:energy"]["newest_db_start"] == "2025-01-01T12:00:00+00:00"
+        assert mock_add.called

--- a/tests/unit_tests/test_get_import_status_for_statistic.py
+++ b/tests/unit_tests/test_get_import_status_for_statistic.py
@@ -1,0 +1,81 @@
+"""Unit tests for get_import_status_for_statistic function."""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from custom_components.import_statistics.import_service_helper import get_import_status_for_statistic
+
+
+@pytest.fixture
+def statistic_id() -> str:
+    """Return a sample statistic id."""
+    return "custom:energy"
+
+
+def test_no_data_empty_statistics(statistic_id: str) -> None:
+    """Test no data status when no statistics are provided."""
+    db_start = dt.datetime(2025, 1, 1, 12, 0, tzinfo=dt.UTC)
+    result = get_import_status_for_statistic(statistic_id, [], db_start)
+
+    assert result["statistic_id"] == statistic_id
+    assert result["status"] == "no data"
+    assert result["newest_import_start"] is None
+    assert result["newest_db_start"] == "2025-01-01T12:00:00+00:00"
+
+
+def test_new_data_when_no_db_record(statistic_id: str) -> None:
+    """Test new data status when there is no existing database record."""
+    import_start = dt.datetime(2025, 1, 1, 12, 0, tzinfo=dt.UTC)
+    statistics = [{"start": import_start}]
+    result = get_import_status_for_statistic(statistic_id, statistics, None)
+
+    assert result["status"] == "new data"
+    assert result["newest_import_start"] == "2025-01-01T12:00:00+00:00"
+    assert result["newest_db_start"] is None
+
+
+def test_new_data_when_import_is_newer(statistic_id: str) -> None:
+    """Test new data status when the import contains a newer timestamp."""
+    import_start = dt.datetime(2025, 1, 2, 12, 0, tzinfo=dt.UTC)
+    db_start = dt.datetime(2025, 1, 1, 12, 0, tzinfo=dt.UTC)
+    statistics = [{"start": import_start}]
+    result = get_import_status_for_statistic(statistic_id, statistics, db_start)
+
+    assert result["status"] == "new data"
+    assert result["newest_import_start"] == "2025-01-02T12:00:00+00:00"
+    assert result["newest_db_start"] == "2025-01-01T12:00:00+00:00"
+
+
+def test_existing_data_when_import_is_older(statistic_id: str) -> None:
+    """Test existing data status when the import only contains older timestamps."""
+    import_start = dt.datetime(2025, 1, 1, 10, 0, tzinfo=dt.UTC)
+    db_start = dt.datetime(2025, 1, 1, 12, 0, tzinfo=dt.UTC)
+    statistics = [{"start": import_start}]
+    result = get_import_status_for_statistic(statistic_id, statistics, db_start)
+
+    assert result["status"] == "existing data"
+    assert result["newest_import_start"] == "2025-01-01T10:00:00+00:00"
+    assert result["newest_db_start"] == "2025-01-01T12:00:00+00:00"
+
+
+def test_existing_data_when_import_equals_db(statistic_id: str) -> None:
+    """Test existing data status when the import's newest timestamp equals the db."""
+    import_start = dt.datetime(2025, 1, 1, 12, 0, tzinfo=dt.UTC)
+    statistics = [{"start": import_start}, {"start": import_start - dt.timedelta(hours=1)}]
+    result = get_import_status_for_statistic(statistic_id, statistics, import_start)
+
+    assert result["status"] == "existing data"
+    assert result["newest_import_start"] == "2025-01-01T12:00:00+00:00"
+
+
+def test_newest_import_converted_to_utc(statistic_id: str) -> None:
+    """Test that import timestamps are converted to UTC before comparison."""
+    local_start = dt.datetime(2025, 1, 1, 13, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_start = dt.datetime(2025, 1, 1, 11, 0, tzinfo=dt.UTC)
+    statistics = [{"start": local_start}]
+    result = get_import_status_for_statistic(statistic_id, statistics, db_start)
+
+    assert result["status"] == "new data"
+    assert result["newest_import_start"] == "2025-01-01T12:00:00+00:00"


### PR DESCRIPTION
Adds optional service response support to `import_statistics.import_from_file` and `import_statistics.import_from_json`.

When the action is called with `response_variable`, the service returns a JSON-serializable dict under the key `results` mapping each `statistic_id` to:
- `has_new_data`: whether the import contains newer data than the database
- `newest_import_start`: latest start timestamp in the import
- `newest_db_start`: latest start timestamp already in the database

The README got updated with usage examples, including a persistent notification for statistics that received no new data.